### PR TITLE
Fix wrong links and errors

### DIFF
--- a/Installation Guides/Server-Installation.md
+++ b/Installation Guides/Server-Installation.md
@@ -20,7 +20,7 @@ Basic Installation Guide:
 ```
 	Add this line above it (if you have DZMS or WAI, add it above their lines):
 ```sqf
-		call compile preprocessFileLineNumbers "\z\addons\dayz_server\DZAI\init\dzai_initserver.sqf";
+		[] call compile preprocessFileLineNumbers "\z\addons\dayz_server\DZAI\init\dzai_initserver.sqf";
 ```		
 3. Drop the DZAI folder from the downloaded file into your server.pbo.
 4. Edit DZAI\init\dzai_config.sqf as to your needs.

--- a/README.md
+++ b/README.md
@@ -22,5 +22,5 @@ DZAI includes many features that can be user-configured:
 Basic Installation Guides:
 ----------------------------------------------------
 
-1. DZAI server-sided installation: [Click here](https://github.com/oiad/DZAI/blob/master/Installation%20Guides/Mission-Installation.md)
-2. DZAI mission(client)-sided installation [Click here](https://github.com/oiad/DZAI/blob/master/Installation%20Guides/Server-Installation.md)
+1. DZAI server-sided installation: [Click here](https://github.com/oiad/DZAI/blob/master/Installation%20Guides/Server-Installation.md)
+2. DZAI mission(client)-sided installation [Click here](https://github.com/oiad/DZAI/blob/master/Installation%20Guides/Mission-Installation.md)


### PR DESCRIPTION
`Error in expression <(isNil "_this") then {_this = []};
if ((count _this) > 0) then {
if ("readoverr>
  Error position: <count _this) > 0) then {
if ("readoverr>
  Error count: Type Object, expected Array,Config entry
File z\addons\dayz_server\DZAI\init\dzai_initserver.sqf, line 17`

The check on _this in initserver doesn't seem to act correctly. This was brought to my attention from Sanexelele's error in discord.